### PR TITLE
Change behaviour of caught errors so as not to break build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* **0.1.2** - Update error handling to prevent build failure
 * **0.1.1** - Updated repo URL in package.json
 * **0.1.0** - Updated text output, and total stats now also returned.
 * **0.0.2** - Correct module now exported. 

--- a/lib/report.js
+++ b/lib/report.js
@@ -22,7 +22,12 @@ var Report = module.exports = function(targetPath, callback) {
       summary: summary
     });
   })
-  .catch(callback);
+  .catch(function(err) {
+    callback(null, {
+      text: err.toString(),
+      summary: { }
+    });
+  });
 };
 
 Report._risks = [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snyk-report",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Assists in generating human readable snyk reports for CI integration",
   "main": "lib/report.js",
   "scripts": {
@@ -17,9 +17,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "colours": "^0.6.0-2",
+    "colours": "0.6.0-2",
     "moment": "2.10.6",
-    "snyk": "1.6.1"
+    "snyk": "1.11.3"
   },
   "devDependencies": {
     "assert": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "colours": "0.6.0-2",
-    "moment": "2.10.6",
-    "snyk": "1.11.3"
+    "colours": "^0.6.0-2",
+    "moment": "^2.10.6",
+    "snyk": "^1.11.3"
   },
   "devDependencies": {
     "assert": "1.3.0",

--- a/test/unit/report.js
+++ b/test/unit/report.js
@@ -74,7 +74,10 @@ context('Report', function() {
         });
 
         it('sends the error to the callback', function() {
-          expect(testCallback).to.have.been.calledWith(Error('sad face'));
+          expect(testCallback).to.have.been.calledWith(null, {
+            text: 'sad face',
+            summary: { }
+          });
         });
 
       });

--- a/test/unit/report.js
+++ b/test/unit/report.js
@@ -75,7 +75,7 @@ context('Report', function() {
 
         it('sends the error to the callback', function() {
           expect(testCallback).to.have.been.calledWith(null, {
-            text: 'sad face',
+            text: 'Error: sad face',
             summary: { }
           });
         });


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
Updates the `catch` in `lib/report.js` so that it calls back with `null` instead of the error. This is to ensure that a failed `snyk-report` call does not fail the build, yet retains visibility of the error returned.

#### What tests does this PR have?
Updated unit test.

#### How can this be tested?
Update the `API` value in `node_modules/snyk/config.default.json` to point to a domain that does not resolve.

`{
  "API": "https://NOTAREALDOMAIN/api/v1",
  "devDeps": false
}`

Run `npm start` in the project directory. You should see the below output in the console.

`Error: getaddrinfo ENOTFOUND`

#### Screenshots / Screencast


#### What gif best describes how you feel about this work?
![](http://static.fjcdn.com/gifs/Bug%252Bkiller%252B9000%252B_180aa7_5272340.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** \*
- [x] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru