### PR TITLE
Support authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 coverage
+/.eslintrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
+* **0.1.4** - Support authentication.
 * **0.1.3** - Updated dependencies.
 * **0.1.2** - Update error handling to prevent build failure
 * **0.1.1** - Updated repo URL in package.json
 * **0.1.0** - Updated text output, and total stats now also returned.
 * **0.0.2** - Correct module now exported. 
 * **0.0.1** - Initial release.
-

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This module can be installed with `npm`.
 
     npm install snyk-report --save-dev
 
+Before this module can be used authentication with the Snyk API will need to be setup. For more details see [Snyk CLI Authentication](https://snyk.io/docs/using-snyk#authentication).
+
+Alternatively this module allows the environment variable `SNYK_API_TOKEN` to be set containing the correct authentication token.
+
 An example script has been included, which demonstrates `snyk-report` being run against either a directory pointed to by the `REPO_DIR` environment variable, or the current directory if it is not defined.
 
     var report = require('snyk-report');

--- a/lib/report.js
+++ b/lib/report.js
@@ -11,6 +11,9 @@ var Report = module.exports = function(targetPath, callback) {
   if (typeof callback !== 'function') {
     throw new Error('callback must be a function');
   }
+  if (process.env.SNYK_API_TOKEN) {
+    snyk.api = process.env.SNYK_API_TOKEN;
+  }
   snyk.test(targetPath, {})
   .then(function(results) {
     var groupedResults = Report._groupResults(results);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snyk-report",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Assists in generating human readable snyk reports for CI integration",
   "main": "lib/report.js",
   "scripts": {

--- a/test/unit/report.js
+++ b/test/unit/report.js
@@ -18,6 +18,41 @@ context('Report', function() {
       expect(report).to.be.a('function');
     });
 
+    context('without a environment token', function() {
+
+      var token;
+
+      before(function() {
+        token = snyk.api;
+        report('NOTEXISTS', function() {});
+      });
+
+      it('does not change the token', function() {
+        expect(snyk.api).to.equal(token);
+      });
+
+    });
+
+    context('with a environment token', function() {
+
+      var token;
+
+      before(function() {
+        token = snyk.api;
+        process.env.SNYK_API_TOKEN = 'TESTTOKEN';
+        report('NOTEXISTS', function() {});
+      });
+
+      after(function() {
+        snyk.api = token;
+      });
+
+      it('sets the token from the environment', function() {
+        expect(snyk.api).to.equal('TESTTOKEN');
+      });
+
+    });
+
     context('without a callback', function() {
 
       it('throws an error', function() {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

Snyk now requires authentication to access their API, this work allows the snyk config to be used or an environment variable.

#### What tests does this PR have?

New tests added to check that the auth details are overridden.

#### How can this be tested?

SNYK_API_TOKEN=xxx npm start

#### Any tech debt?

#### Screenshots / Screencast

#### What gif best describes how you feel about this work?
![]()

- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

By approving a review you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
